### PR TITLE
Add functions for lab and xyz

### DIFF
--- a/conversions.js
+++ b/conversions.js
@@ -27,8 +27,13 @@ module.exports = {
   keyword2hsl: keyword2hsl,
   keyword2hsv: keyword2hsv,
   keyword2cmyk: keyword2cmyk,
+  keyword2lab: keyword2lab,
+  keyword2xyz: keyword2xyz,
   
   xyz2rgb: xyz2rgb,
+  xyz2lab: xyz2lab,
+  
+  lab2xyz: lab2xyz,
 }
 
 
@@ -318,6 +323,47 @@ function xyz2rgb(xyz) {
   return [r * 255, g * 255, b * 255];
 }
 
+function xyz2lab(xyz) {
+  var x = xyz[0],
+      y = xyz[1],
+      z = xyz[2],
+      l, a, b;
+
+  x /= 95.047;
+  y /= 100;
+  z /= 108.883;
+
+  x = x > 0.008856 ? Math.pow(x, 1/3) : (7.787 * x) + (16 / 116);
+  y = y > 0.008856 ? Math.pow(y, 1/3) : (7.787 * y) + (16 / 116);
+  z = z > 0.008856 ? Math.pow(z, 1/3) : (7.787 * z) + (16 / 116);
+
+  l = (116 * y) - 16;
+  a = 500 * (x - y);
+  b = 200 * (y - z);
+  
+  return [l, a, b];
+}
+
+function lab2xyz(lab) {
+  var l = lab[0],
+      a = lab[1],
+      b = lab[2],
+      x, y, z, y2;
+
+  if (l <= 8) {
+    y = (l * 100) / 903.3;
+    y2 = (7.787 * (y / 100)) + (16 / 116);
+  } else {
+    y = 100 * Math.pow((l + 16) / 116, 3);
+    y2 = Math.pow(y / 100, 1/3);
+  }
+
+  x = x / 95.047 <= 0.008856 ? x = (95.047 * ((a / 500) + y2 - (16 / 116))) / 7.787 : 95.047 * Math.pow((a / 500) + y2, 3);
+
+  z = z / 108.883 <= 0.008859 ? z = (108.883 * (y2 - (b / 200) - (16 / 116))) / 7.787 : 108.883 * Math.pow(y2 - (b / 200), 3);
+
+  return [x, y, z];
+}
 
 function keyword2rgb(keyword) {
   return cssKeywords[keyword];
@@ -333,6 +379,14 @@ function keyword2hsv(args) {
 
 function keyword2cmyk(args) {
   return rgb2cmyk(keyword2rgb(args));
+}
+
+function keyword2lab(args) {
+  return rgb2lab(keyword2rgb(args));
+}
+
+function keyword2xyz(args) {
+  return rgb2xyz(keyword2rgb(args));
 }
 
 var cssKeywords = {

--- a/test/basic.js
+++ b/test/basic.js
@@ -27,8 +27,13 @@ assert.deepEqual(convert.keyword2rgb("blue"), [0, 0, 255]);
 assert.deepEqual(convert.keyword2hsl("blue"), [240, 100, 50]);
 assert.deepEqual(convert.keyword2hsv("blue"), [240, 100, 100]);
 assert.deepEqual(convert.keyword2cmyk("blue"), [100, 100, 0, 0]);
+assert.deepEqual(convert.keyword2lab("blue"), [32, 79, -108]);
+assert.deepEqual(convert.keyword2xyz("blue"), [18, 7, 95]);
 
 assert.deepEqual(convert.xyz2rgb([25, 40, 15]), [97, 190, 85]);
+assert.deepEqual(convert.xyz2lab([25, 40, 15]), [69, -48, 44]);
+
+assert.deepEqual(convert.lab2xyz([69, -48, 44]), [25, 39, 15]);
 
 // non-array arguments
 assert.deepEqual(convert.hsl2rgb(96, 48, 59), [140, 201, 100]);
@@ -92,5 +97,12 @@ assert.deepEqual(convert["keyword"]["rgb"](val), convert.keyword2rgb(val));
 assert.deepEqual(convert["keyword"]["hsl"](val), convert.keyword2hsl(val));
 assert.deepEqual(convert["keyword"]["hsv"](val), convert.keyword2hsv(val));
 assert.deepEqual(convert["keyword"]["cmyk"](val), convert.keyword2cmyk(val));
+assert.deepEqual(convert["keyword"]["lab"](val), convert.keyword2lab(val));
+assert.deepEqual(convert["keyword"]["xyz"](val), convert.keyword2xyz(val));
 
-assert.deepEqual(convert["xyz"]["rgb"]([25, 40, 15]), [97, 190, 85]);
+val = [25, 40, 15]
+assert.deepEqual(convert["xyz"]["rgb"](val), convert.xyz2rgb(val));
+assert.deepEqual(convert["xyz"]["lab"](val), convert.xyz2lab(val));
+
+val = [69, -48, 44];
+assert.deepEqual(convert["lab"]["xyz"](val), [25, 39, 15]);


### PR DESCRIPTION
I added functions related to lab and xyz spaces, along with the appropriate tests (I didn't add any for lines 48-66 in test/basic.js). I admit that I'm not an expert in color spaces by any means, but I tested the functions and they seem to provide close values.

``` javascript
rgb2lab(140, 200, 100); // [ 75, -37, 44 ]
rgb2xyz(140, 200, 100); // [ 34, 48, 20 ]
xyz2lab(34, 48, 20); // [ 75, -37, 43 ]
```

Functions that were added were `xyz2lab`, `lab2xyz`, `keyword2lab`, and `keyword2xyz`.
