### PR TITLE
Fixed error in hsl2hsv conversion

### DIFF
--- a/conversions.js
+++ b/conversions.js
@@ -209,7 +209,7 @@ function hsl2hsv(hsl) {
   s *= (l <= 1) ? l : 2 - l;
   v = (l + s) / 2;
   sv = (2 * s) / (l + s);
-  return [h, s * 100, v * 100];
+  return [h, sv * 100, v * 100];
 }
 
 function hsl2cmyk(args) {


### PR DESCRIPTION
It seems there was a typo in the hsl2hsv conversion function. This should fix it to the saturation is now converted correctly into the hsv color space.
