### PR TITLE
add direct lab2rgb and constrain max values in xyz2rgb

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,7 +1,7 @@
 {
     "name": "color-convert",
     "description": "Plain color conversion functions",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "author": "Heather Arthur <fayearthur@gmail.com>",
     "repository": "harthur/color-convert",
     "keywords": ["color", "colour", "rgb"],

--- a/conversions.js
+++ b/conversions.js
@@ -34,6 +34,7 @@ module.exports = {
   xyz2lab: xyz2lab,
   
   lab2xyz: lab2xyz,
+  lab2rgb: lab2rgb,
 }
 
 
@@ -316,9 +317,9 @@ function xyz2rgb(xyz) {
   b = b > 0.0031308 ? ((1.055 * Math.pow(b, 1.0 / 2.4)) - 0.055)
     : b = (b * 12.92);
 
-  r = (r < 0) ? 0 : r;
-  g = (g < 0) ? 0 : g;
-  b = (b < 0) ? 0 : b;
+  r = Math.min(Math.max(0, r), 1);
+  g = Math.min(Math.max(0, g), 1);
+  b = Math.min(Math.max(0, b), 1);
 
   return [r * 255, g * 255, b * 255];
 }
@@ -363,6 +364,10 @@ function lab2xyz(lab) {
   z = z / 108.883 <= 0.008859 ? z = (108.883 * (y2 - (b / 200) - (16 / 116))) / 7.787 : 108.883 * Math.pow(y2 - (b / 200), 3);
 
   return [x, y, z];
+}
+
+function lab2rgb(args) {
+  return xyz2rgb(lab2xyz(args));
 }
 
 function keyword2rgb(keyword) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "color-convert",
     "description": "Plain color conversion functions",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "author": "Heather Arthur <fayearthur@gmail.com>",
     "repository": {
         "type": "git",

--- a/test/basic.js
+++ b/test/basic.js
@@ -31,9 +31,11 @@ assert.deepEqual(convert.keyword2lab("blue"), [32, 79, -108]);
 assert.deepEqual(convert.keyword2xyz("blue"), [18, 7, 95]);
 
 assert.deepEqual(convert.xyz2rgb([25, 40, 15]), [97, 190, 85]);
+assert.deepEqual(convert.xyz2rgb([50, 100, 100]), [0, 255, 241]);
 assert.deepEqual(convert.xyz2lab([25, 40, 15]), [69, -48, 44]);
 
 assert.deepEqual(convert.lab2xyz([69, -48, 44]), [25, 39, 15]);
+assert.deepEqual(convert.lab2rgb([75, 20, -30]), [194, 175, 240]);
 
 // non-array arguments
 assert.deepEqual(convert.hsl2rgb(96, 48, 59), [140, 201, 100]);


### PR DESCRIPTION
I noticed that you're constraining xyz2rgb to produce values of at least 0, but not of at most 255. I also added a direct lab2rgb.

Thanks for your work. This has been very useful.
