### PR TITLE
Fix issue with 'require' statement reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ converter.rgb([140, 200, 100])       // args can be an array
 Get direct conversion functions with no fancy objects:
 
 ```javascript
-require("convert").rgb2hsl([140, 200, 100]);   // [96, 48, 59]
+require("color-convert").rgb2hsl([140, 200, 100]);   // [96, 48, 59]
 ```
 
 ### Unrounded


### PR DESCRIPTION
Was getting `Error: Cannot find module 'convert'` when using `require('convert')`. I switched 'convert' to 'color-convert' and this fixed the issue. This update addresses the incorrect reference in the README file. 
