### PR TITLE
Fix rgb2hwb global leaks

### DIFF
--- a/conversions.js
+++ b/conversions.js
@@ -128,8 +128,8 @@ function rgb2hwb(rgb) {
   var r = rgb[0],
       g = rgb[1],
       b = rgb[2],
-      h = rgb2hsl(rgb)[0]
-      w = 1/255 * Math.min(r, Math.min(g, b))
+      h = rgb2hsl(rgb)[0],
+      w = 1/255 * Math.min(r, Math.min(g, b)),
       b = 1 - 1/255 * Math.max(r, Math.max(g, b));
 
   return [h, w * 100, b * 100];


### PR DESCRIPTION
There are commas missed which causes global leaks in color.js and all depending libs.
