### PR TITLE
Preserve saturation in HSL->HSV and HSV->HSL conversions

### DIFF
--- a/conversions.js
+++ b/conversions.js
@@ -251,19 +251,16 @@ convert.hsl.hsv = function (hsl) {
 	var h = hsl[0];
 	var s = hsl[1] / 100;
 	var l = hsl[2] / 100;
+	var smin = s;
+	var lmin = Math.max(l, 0.01);
 	var sv;
 	var v;
 
-	if (l === 0) {
-		// no need to do calc on black
-		// also avoids divide by 0 error
-		return [0, 0, 0];
-	}
-
 	l *= 2;
 	s *= (l <= 1) ? l : 2 - l;
+	smin *= lmin <= 1 ? lmin : 2 - lmin;
 	v = (l + s) / 2;
-	sv = (2 * s) / (l + s);
+	sv = l === 0 ? (2 * smin) / (lmin + smin) : (2 * s) / (l + s);
 
 	return [h, sv * 100, v * 100];
 };
@@ -300,12 +297,15 @@ convert.hsv.hsl = function (hsv) {
 	var h = hsv[0];
 	var s = hsv[1] / 100;
 	var v = hsv[2] / 100;
+	var vmin = Math.max(v, 0.01);
+	var lmin;
 	var sl;
 	var l;
 
 	l = (2 - s) * v;
-	sl = s * v;
-	sl /= (l <= 1) ? l : 2 - l;
+	lmin = (2 - s) * vmin;
+	sl = s * vmin;
+	sl /= (lmin <= 1) ? lmin : 2 - lmin;
 	sl = sl || 0;
 	l /= 2;
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -137,9 +137,17 @@ assert.deepEqual(round(convert.keyword.rgb.raw('blue')), [0, 0, 255]);
 assert.deepEqual(convert.rgb.keyword.raw([255, 228, 196]), 'bisque');
 
 assert.deepEqual(round(convert.hsv.hsl.raw([96, 50, 78])), [96, 47, 58.5]);
-assert.deepEqual(round(convert.hsl.hsv.raw([96, 48, 59])), [96, 50, 78.7]);
+assert.deepEqual(round(convert.hsv.hsl.raw([302, 32, 55])), [302, 19.0, 46.2]);
+assert.deepEqual(round(convert.hsv.hsl.raw([267, 19, 89])), [267, 43.5, 80.5]);
+assert.deepEqual(round(convert.hsv.hsl.raw([267, 91, 95])), [267, 89.6, 51.8]);
+assert.deepEqual(round(convert.hsv.hsl.raw([267, 91, 12])), [267, 83.5, 6.5]);
+assert.deepEqual(round(convert.hsv.hsl.raw([180, 50, 0])), [180, 33.3, 0]); // Preserve saturation
 
 assert.deepEqual(round(convert.hsl.hsv.raw([96, 48, 59])), [96, 50, 78.7]);
+assert.deepEqual(round(convert.hsl.hsv.raw([120, 54, 61])), [120, 51.3, 82.1]);
+assert.deepEqual(round(convert.hsl.hsv.raw([27, 51, 43])), [27, 67.5, 64.9]);
+assert.deepEqual(round(convert.hsl.hsv.raw([241, 17, 79])), [241, 8.6, 82.6]);
+assert.deepEqual(round(convert.hsl.hsv.raw([120, 50, 0])), [120, 66.7, 0]); // Preserve saturation
 
 assert.deepEqual(round(convert.xyz.rgb.raw([25, 40, 15])), [97.4, 189.9, 85]);
 assert.deepEqual(round(convert.rgb.xyz.raw([92, 191, 84])), [24.6, 40.2, 14.8]);


### PR DESCRIPTION
Although it's technically true that black in HSV and HSL can be expressed as `[0, 0, 0]` (or any combination of HS values as long as L/V is 0), one might expect the hue/saturation values to be preserved converting between these two models. For example, `convert.hsv.hsl([120, 50, 0])` currently returns `[0, 0, 0]`, where one might expect it to return `[120, 67, 0]`.

A practical use case: two-axis draggable color pickers (such as the one in Adobe Photoshop, or Chrome Web Inspector) typically show S on the horizontal axis and V on the vertical axis. In this setup, the entire bottom edge of the color picker rectangle is black. If you were to build such a color picker as an option for picking CSS color values, you would have to convert HSV->HSL since CSS does not support HSL. However, if the HSV->HSL conversion for black defaults to `[0, 0, 0]`, the loss of information about HS in the conversion means that, in order to preserve the user-selected position on the color picker, the implementer has to save the HS values themselves prior to the conversion, and reapply them after the conversion.

This proposed solution preserves the current HSV->HSL and HSL->HSV formulation for calculating L/V, but uses 0.01 to calculate S. As far as I know, this is safe as the end value of S when converting either way does not change until L > 50, in which case the logic won't run anyway.