### PR TITLE
Conversions for gray

### DIFF
--- a/conversions.js
+++ b/conversions.js
@@ -26,7 +26,8 @@ var convert = module.exports = {
 	ansi16: {channels: 1},
 	ansi256: {channels: 1},
 	hcg: {channels: 3},
-	apple: {channels: 3}
+	apple: {channels: 3},
+	gray: {channels: 1}
 };
 
 // hide .channels property
@@ -805,4 +806,37 @@ convert.apple.rgb = function (apple) {
 
 convert.rgb.apple = function (rgb) {
 	return [(rgb[0] / 255) * 65535, (rgb[1] / 255) * 65535, (rgb[2] / 255) * 65535];
+};
+
+convert.gray.rgb = function (args) {
+	return [args[0] / 100 * 255, args[0] / 100 * 255, args[0] / 100 * 255];
+};
+
+convert.gray.hsl = convert.gray.hsv = function (args) {
+	return [0, 0, args[0]];
+};
+
+convert.gray.hwb = function (gray) {
+	return [0, 100, gray[0]];
+};
+
+convert.gray.cmyk = function (gray) {
+	return [0, 0, 0, gray[0]];
+};
+
+convert.gray.lab = function (gray) {
+	return [gray[0], 0, 0];
+};
+
+convert.gray.hex = function (gray) {
+	var val = Math.round(gray[0] / 100 * 255) & 0xFF;
+	var integer = (val << 16) + (val << 8) + val;
+
+	var string = integer.toString(16).toUpperCase();
+	return '000000'.substring(string.length) + string;
+};
+
+convert.rgb.gray = function (rgb) {
+	var val = (rgb[0] + rgb[1] + rgb[2]) / 3;
+	return [val / 255 * 100];
 };

--- a/test/basic.js
+++ b/test/basic.js
@@ -201,3 +201,21 @@ for (var k in keywords) {
 		assert.deepEqual(keywords[derived], keywords[k]);
 	}
 }
+
+// basic gray tests
+assert.deepEqual(convert.gray.rgb([0]), [0, 0, 0]);
+assert.deepEqual(convert.gray.rgb([50]), [128, 128, 128]);
+assert.deepEqual(convert.gray.rgb([100]), [255, 255, 255]);
+assert.deepEqual(convert.gray.hsl([50]), [0, 0, 50]);
+assert.deepEqual(convert.gray.hsv([50]), [0, 0, 50]);
+assert.deepEqual(convert.gray.hwb([50]), [0, 100, 50]);
+assert.deepEqual(convert.gray.cmyk([50]), [0, 0, 0, 50]);
+assert.deepEqual(convert.gray.lab([50]), [50, 0, 0]);
+assert.deepEqual(convert.gray.hex([50]), '808080');
+assert.deepEqual(convert.gray.hex([100]), 'FFFFFF');
+assert.deepEqual(convert.gray.hex([0]), '000000');
+
+assert.deepEqual(convert.rgb.gray([0, 0, 0]), [0]);
+assert.deepEqual(convert.rgb.gray([128, 128, 128]), [50]);
+assert.deepEqual(convert.rgb.gray([255, 255, 255]), [100]);
+assert.deepEqual(convert.rgb.gray([0, 128, 255]), [50]);


### PR DESCRIPTION
This adds support for conversion from shades of gray to and from other colors.
The purpose of this is to make it easier to convert to and from the new CSS4
gray() color notation.

https://drafts.csswg.org/css-color/#grays

I plan to add more tests but want to make sure this is kosher first.