### PR TITLE
add support for shorthand hex color

### DIFF
--- a/conversions.js
+++ b/conversions.js
@@ -640,12 +640,20 @@ convert.rgb.hex = function (args) {
 };
 
 convert.hex.rgb = function (args) {
-	var match = args.toString(16).match(/[a-f0-9]{6}/i);
+	var match = args.toString(16).match(/[a-f0-9]{6}|[a-f0-9]{3}/i);
 	if (!match) {
 		return [0, 0, 0];
 	}
 
-	var integer = parseInt(match[0], 16);
+	var colorString = match[0];
+
+	if (match[0].length === 3) {
+		colorString = colorString.split('').map(function (char) {
+			return char + char;
+		}).join('');
+	}
+
+	var integer = parseInt(colorString, 16);
 	var r = (integer >> 16) & 0xFF;
 	var g = (integer >> 8) & 0xFF;
 	var b = integer & 0xFF;

--- a/test/basic.js
+++ b/test/basic.js
@@ -115,6 +115,8 @@ assert.deepEqual(convert.ansi16.rgb(103), [255, 255, 0]);
 assert.deepEqual(convert.ansi256.rgb(175), [204, 102, 153]);
 
 assert.deepEqual(convert.hex.rgb('ABCDEF'), [171, 205, 239]);
+assert.deepEqual(convert.hex.rgb('AABBCC'), [170, 187, 204]);
+assert.deepEqual(convert.hex.rgb('ABC'), [170, 187, 204]);
 
 assert.deepEqual(convert.hcg.rgb([96, 39, 64]), [139, 199, 100]);
 assert.deepEqual(convert.hcg.hsv([96, 39, 64]), [96, 50, 78]);


### PR DESCRIPTION
Allows one to specify shorthand hex colors like `#f1a` where the hex digits are repeated. I assume this is all that is necessary so it will be available in https://github.com/chalk/chalk/pull/140?