### PR TITLE
Fix shadowed models variable

### DIFF
--- a/route.js
+++ b/route.js
@@ -11,11 +11,10 @@ var conversions = require('./conversions');
 	conversions that are not possible simply are not included.
 */
 
-// https://jsperf.com/object-keys-vs-for-in-with-closure/3
-var models = Object.keys(conversions);
-
 function buildGraph() {
 	var graph = {};
+	// https://jsperf.com/object-keys-vs-for-in-with-closure/3
+	var models = Object.keys(conversions);
 
 	for (var len = models.length, i = 0; i < len; i++) {
 		graph[models[i]] = {


### PR DESCRIPTION
Models is re-declared on line 81 of `route.js` which was causing webpack's uglification/optimisation to throw errors in prod builds.

I have moved the first models to the `buildGraph` scope which fixes the issue as the `conversions` models was only ever used in that function.

Closes #50 