### PR TITLE
Bump color-name to 1.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "xo": "0.11.2"
   },
   "dependencies": {
-    "color-name": "1.1.1"
+    "color-name": "1.1.3"
   }
 }


### PR DESCRIPTION
This only contains minor changes (set [diff](https://github.com/colorjs/color-name/compare/b47de1bf75da523d6d6061a41f7f0c9bb7c213bf...v1.1.3)) but it's nice clear out the `npm outdated --depth=10` list 🙂