### PR TITLE
Bump color-name to 1.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "xo": "0.11.2"
   },
   "dependencies": {
-    "color-name": "1.1.3"
+    "color-name": "~1.1.4"
   }
 }


### PR DESCRIPTION
This PR also expands the version range to allow patch releases so there doesn't have to be a new release of color-convert every time color-name makes a release.