### PR TITLE
Optimize start up time by using rollup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules/
 yarn-error.log
 yarn.lock
+dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - 7
-  - 8
-  - 9
+  - node
+  - lts/*
   - 10
-  - 11
-  - stable

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "node test/basic.js"
   },
   "engines": {
-    "node": ">=7.0.0"
+    "node": ">=10.0.0"
   },
   "keywords": [
     "color",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,14 @@
   "repository": "Qix-/color-convert",
   "scripts": {
     "pretest": "xo",
-    "test": "node test/basic.js"
+    "prepublish": "npm run build",
+    "test": "npm run build && node test/basic.js",
+    "build": "rollup --config"
   },
   "engines": {
     "node": ">=10.0.0"
   },
+  "main": "dist/index.js",
   "keywords": [
     "color",
     "colour",
@@ -27,9 +30,7 @@
     "ansi16"
   ],
   "files": [
-    "index.js",
-    "conversions.js",
-    "route.js"
+    "dist/"
   ],
   "xo": {
     "rules": {
@@ -40,6 +41,7 @@
   },
   "devDependencies": {
     "chalk": "^2.4.2",
+    "rollup": "^2.28.2",
     "xo": "^0.24.0"
   },
   "dependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,11 @@
+/* eslint-disable import/extensions */
+import pkg from './package.json';
+
+export default {
+	input: 'src/index.js',
+	output: {
+		file: pkg.main,
+		format: 'cjs'
+	},
+	external: Object.keys(pkg.dependencies)
+};

--- a/src/conversions.js
+++ b/src/conversions.js
@@ -29,8 +29,6 @@ const convert = {
 	gray: {channels: 1, labels: ['gray']}
 };
 
-export default convert;
-
 // Hide .channels and .labels properties
 for (const model of Object.keys(convert)) {
 	if (!('channels' in convert[model])) {
@@ -836,4 +834,11 @@ convert.gray.hex = function (gray) {
 convert.rgb.gray = function (rgb) {
 	const val = (rgb[0] + rgb[1] + rgb[2]) / 3;
 	return [val / 255 * 100];
+};
+
+const models = Object.keys(convert);
+
+export {
+	convert as conversions,
+	models
 };

--- a/src/conversions.js
+++ b/src/conversions.js
@@ -1,6 +1,6 @@
 /* MIT license */
 /* eslint-disable no-mixed-operators */
-const cssKeywords = require('color-name');
+import cssKeywords from 'color-name';
 
 // NOTE: conversions should only return primitive values (i.e. arrays, or
 //       values that give correct `typeof` results).
@@ -29,7 +29,7 @@ const convert = {
 	gray: {channels: 1, labels: ['gray']}
 };
 
-module.exports = convert;
+export default convert;
 
 // Hide .channels and .labels properties
 for (const model of Object.keys(convert)) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-const conversions = require('./conversions');
-const route = require('./route');
+import conversions from './conversions';
+import route from './route';
 
 const convert = {};
 
@@ -78,4 +78,4 @@ models.forEach(fromModel => {
 	});
 });
 
-module.exports = convert;
+export default convert;

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,7 @@
-import conversions from './conversions';
+import {conversions, models} from './conversions';
 import route from './route';
 
 const convert = {};
-
-const models = Object.keys(conversions);
 
 function wrapRaw(fn) {
 	const wrappedFn = function (...args) {

--- a/src/route.js
+++ b/src/route.js
@@ -1,4 +1,4 @@
-const conversions = require('./conversions');
+import conversions from './conversions';
 
 /*
 	This function routes a model to all other models.
@@ -75,7 +75,7 @@ function wrapConversion(toModel, graph) {
 	return fn;
 }
 
-module.exports = function (fromModel) {
+export default function (fromModel) {
 	const graph = deriveBFS(fromModel);
 	const conversion = {};
 
@@ -93,5 +93,4 @@ module.exports = function (fromModel) {
 	}
 
 	return conversion;
-};
-
+}

--- a/src/route.js
+++ b/src/route.js
@@ -1,4 +1,4 @@
-import conversions from './conversions';
+import {conversions, models} from './conversions';
 
 /*
 	This function routes a model to all other models.
@@ -13,9 +13,8 @@ import conversions from './conversions';
 
 function buildGraph() {
 	const graph = {};
-	// https://jsperf.com/object-keys-vs-for-in-with-closure/3
-	const models = Object.keys(conversions);
 
+	// https://jsperf.com/object-keys-vs-for-in-with-closure/3
 	for (let len = models.length, i = 0; i < len; i++) {
 		graph[models[i]] = {
 			// http://jsperf.com/1-vs-infinity
@@ -79,7 +78,6 @@ export default function (fromModel) {
 	const graph = deriveBFS(fromModel);
 	const conversion = {};
 
-	const models = Object.keys(graph);
 	for (let len = models.length, i = 0; i < len; i++) {
 		const toModel = models[i];
 		const node = graph[toModel];

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,12 +1,9 @@
 const assert = require('assert');
 const chalk = require('chalk');
 const keywords = require('color-name');
-
-const conversions = require('../conversions');
-
 const convert = require('..');
 
-const models = Object.keys(conversions);
+const models = Object.keys(convert);
 for (let len = models.length, i = 0; i < len; i++) {
 	const toModel = models[i];
 	for (let j = 0; j < len; j++) {


### PR DESCRIPTION
Seeing chalk/chalk#300 I thought it's worth to try to see if rollup can do any good.

By bundling everything into one file and removing some redundant `Object.keys()` calls require time dropped by 1/3.

Old:

```
Start time: (2018-09-29 23:56:15 UTC) [treshold=0%]
 #  module                                                        time  %
 1  text-table (node_modules/text-table/index.js)                  1ms  ▇▇▇▇ 6%
 2  date-time (node_modules/date-time/index.js)                    1ms  ▇▇▇▇ 6%
 3  parse-ms (node_modules/parse-ms/index.js)                      2ms  ▇▇▇▇▇▇▇ 11%
 4  pretty-ms (node_modules/pretty-ms/index.js)                    3ms  ▇▇▇▇▇▇▇▇▇▇ 17%
 5  ansi-styles (node_modules/tim.../ansi-styles/ansi-styles.js)   1ms  ▇▇▇▇ 6%
 6  strip-ansi (node_modules/time...modules/strip-ansi/index.js)   1ms  ▇▇▇▇ 6%
 7  has-color (node_modules/has-color/index.js)                    2ms  ▇▇▇▇▇▇▇ 11%
 8  chalk (node_modules/time-requ...node_modules/chalk/index.js)   5ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 28%
 9  color-name (node_modules/color-name/index.js)                  1ms  ▇▇▇▇ 6%
10  ./conversions (conversions.js)                                 4ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 22%
11  ./conversions (conversions.js)                                 1ms  ▇▇▇▇ 6%
12  ./route (route.js)                                             1ms  ▇▇▇▇ 6%
13  ./index.js (index.js)                                          7ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 39%
Total require(): 13
Total time: 18ms
```

New:

```
Start time: (2018-09-29 23:56:55 UTC) [treshold=0%]
 #  module                                                        time  %
 1  text-table (node_modules/text-table/index.js)                  1ms  ▇▇▇▇ 6%
 2  date-time (node_modules/date-time/index.js)                    1ms  ▇▇▇▇ 6%
 3  parse-ms (node_modules/parse-ms/index.js)                      1ms  ▇▇▇▇ 6%
 4  pretty-ms (node_modules/pretty-ms/index.js)                    2ms  ▇▇▇▇▇▇▇ 11%
 5  ansi-styles (node_modules/tim.../ansi-styles/ansi-styles.js)   1ms  ▇▇▇▇ 6%
 6  strip-ansi (node_modules/time...modules/strip-ansi/index.js)   1ms  ▇▇▇▇ 6%
 7  has-color (node_modules/has-color/index.js)                    2ms  ▇▇▇▇▇▇▇ 11%
 8  chalk (node_modules/time-requ...node_modules/chalk/index.js)   6ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 33%
 9  color-name (node_modules/color-name/index.js)                  1ms  ▇▇▇▇ 6%
10  ./lib/index.js (lib/index.js)                                  5ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 28%
Total require(): 10
Total time: 18ms
```

Look at the bottom (everything after `chalk`) for the result for `color-convert`.

Tested using `time-require` and Node.js 10.10.

Note: This should be a semver major release as users can't deep-require into individual files anymore.