### PR TITLE
Drop support for Node.js <6 and use some modern Syntax.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - 4
-  - 5
   - 6
-  - 7
+  - 8
+  - 10
   - stable

--- a/index.js
+++ b/index.js
@@ -6,13 +6,13 @@ var convert = {};
 var models = Object.keys(conversions);
 
 function wrapRaw(fn) {
-	var wrappedFn = function (args) {
-		if (args === undefined || args === null) {
-			return args;
+	var wrappedFn = function (...args) {
+		if (args.length === 0) {
+			return undefined;
 		}
 
-		if (arguments.length > 1) {
-			args = Array.prototype.slice.call(arguments);
+		if (args.length === 1 && Array.isArray(args[0])) {
+			args = args[0];
 		}
 
 		return fn(args);
@@ -27,13 +27,13 @@ function wrapRaw(fn) {
 }
 
 function wrapRounded(fn) {
-	var wrappedFn = function (args) {
-		if (args === undefined || args === null) {
-			return args;
+	var wrappedFn = function (...args) {
+		if (args.length === 0) {
+			return undefined;
 		}
 
-		if (arguments.length > 1) {
-			args = Array.prototype.slice.call(arguments);
+		if (args.length === 1 && Array.isArray(args[0])) {
+			args = args[0];
 		}
 
 		var result = fn(args);

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
       "operator-linebreak": 0
     }
   },
+  "engines": {
+    "node": ">=6.0"
+  },
   "devDependencies": {
     "chalk": "1.1.1",
     "xo": "0.11.2"


### PR DESCRIPTION
I wonder if the breaking change of dropping Node 4 and 5 wouldn't be a great time to also remove support for passing an array to `color-convert`. With the spread parameter it's really not much of a hassle for consumers and it'd simplify the code a bit.