### PR TITLE
Use 4 largest bits for rgb->ansi256 gray check

### DIFF
--- a/conversions.js
+++ b/conversions.js
@@ -550,7 +550,7 @@ convert.rgb.ansi256 = function (args) {
 
 	// We use the extended greyscale palette here, with the exception of
 	// black and white. normal palette only has 4 greyscale shades.
-	if (r === g && g === b) {
+	if (r >> 4 === g >> 4 && g >> 4 === b >> 4) {
 		if (r < 8) {
 			return 16;
 		}

--- a/test/basic.js
+++ b/test/basic.js
@@ -235,3 +235,6 @@ assert.deepStrictEqual(convert.rgb.gray([0, 0, 0]), [0]);
 assert.deepStrictEqual(convert.rgb.gray([128, 128, 128]), [50]);
 assert.deepStrictEqual(convert.rgb.gray([255, 255, 255]), [100]);
 assert.deepStrictEqual(convert.rgb.gray([0, 128, 255]), [50]);
+
+// https://github.com/Qix-/color-convert/issues/74
+assert.deepStrictEqual(convert.rgb.ansi256(40, 38, 41), 235);


### PR DESCRIPTION
Fixes #74 
```javascript
console.log(convert.hex.ansi256('#282629')); // 235
```