### PR TITLE
fix: improve performance by prevent run `for` in root of file

### DIFF
--- a/conversions.js
+++ b/conversions.js
@@ -6,9 +6,15 @@ const cssKeywords = require('color-name');
 //       values that give correct `typeof` results).
 //       do not use box values types (i.e. Number(), String(), etc.)
 
-const reverseKeywords = {};
-for (const key of Object.keys(cssKeywords)) {
-	reverseKeywords[cssKeywords[key]] = key;
+const reverseKeywords = new Map();
+function findReverseKeyword(rgb) {
+	if (reverseKeywords.size === 0) {
+		for (const key of Object.keys(cssKeywords)) {
+			reverseKeywords.set(cssKeywords[key], key);
+		}
+	}
+
+	return reverseKeywords.get(rgb);
 }
 
 const convert = {
@@ -175,7 +181,7 @@ function comparativeDistance(x, y) {
 }
 
 convert.rgb.keyword = function (rgb) {
-	const reversed = reverseKeywords[rgb];
+	const reversed = findReverseKeyword(rgb);
 	if (reversed) {
 		return reversed;
 	}

--- a/conversions.js
+++ b/conversions.js
@@ -6,15 +6,16 @@ const cssKeywords = require('color-name');
 //       values that give correct `typeof` results).
 //       do not use box values types (i.e. Number(), String(), etc.)
 
-const reverseKeywords = new Map();
+let reverseKeywords = null;
 function findReverseKeyword(rgb) {
-	if (reverseKeywords.size === 0) {
+	if (reverseKeywords === null) {
+		reverseKeywords = {};
 		for (const key of Object.keys(cssKeywords)) {
-			reverseKeywords.set(cssKeywords[key], key);
+			reverseKeywords[cssKeywords[key]] = key;
 		}
 	}
 
-	return reverseKeywords.get(rgb);
+	return reverseKeywords[rgb];
 }
 
 const convert = {

--- a/conversions.js
+++ b/conversions.js
@@ -6,44 +6,20 @@ const cssKeywords = require('color-name');
 //       values that give correct `typeof` results).
 //       do not use box values types (i.e. Number(), String(), etc.)
 
-const reverseKeywords = (cssKeywords => {
-	let filled = false;
-	let keywords = null;
-	let keywordKeys = null;
+let reverseKeywords = null;
+let reverseKeywordsKeys = null;
 
-	const fill = () => {
-		filled = true;
-		if (keywords === null) {
-			keywords = {};
-			keywordKeys = Object.keys(cssKeywords);
-			for (const key of keywordKeys) {
-				keywords[cssKeywords[key]] = key;
-			}
-		}
-	};
+function fillReverseKeywords() {
+	if (reverseKeywords) {
+		return;
+	}
 
-	const allKeys = () => {
-		if (filled === false) {
-			fill();
-		}
-
-		return keywordKeys;
-	};
-
-	const find = rgb => {
-		if (filled === false) {
-			fill();
-		}
-
-		return keywords[rgb];
-	};
-
-	const each = callback => {
-		allKeys().forEach(key => callback(key, cssKeywords[key]));
-	};
-
-	return {allKeys, find, each};
-})(cssKeywords);
+	reverseKeywords = {};
+	reverseKeywordsKeys = Object.keys(cssKeywords);
+	for (const key of reverseKeywordsKeys) {
+		reverseKeywords[cssKeywords[key]] = key;
+	}
+}
 
 const convert = {
 	rgb: {channels: 3, labels: 'rgb'},
@@ -209,7 +185,9 @@ function comparativeDistance(x, y) {
 }
 
 convert.rgb.keyword = function (rgb) {
-	const reversed = reverseKeywords.find(rgb);
+	fillReverseKeywords();
+
+	const reversed = reverseKeywords[rgb];
 	if (reversed) {
 		return reversed;
 	}
@@ -217,7 +195,9 @@ convert.rgb.keyword = function (rgb) {
 	let currentClosestDistance = Infinity;
 	let currentClosestKeyword;
 
-	reverseKeywords.each((key, value) => {
+	reverseKeywordsKeys.forEach(key => {
+		const value = cssKeywords[key];
+
 		// Compute comparative distance
 		const distance = comparativeDistance(rgb, value);
 

--- a/conversions.js
+++ b/conversions.js
@@ -6,17 +6,40 @@ const cssKeywords = require('color-name');
 //       values that give correct `typeof` results).
 //       do not use box values types (i.e. Number(), String(), etc.)
 
-let reverseKeywords = null;
-function findReverseKeyword(rgb) {
-	if (reverseKeywords === null) {
-		reverseKeywords = {};
-		for (const key of Object.keys(cssKeywords)) {
-			reverseKeywords[cssKeywords[key]] = key;
-		}
-	}
+const reverseKeywords = (cssKeywords => {
+	let filled = false;
+	let keywords = null;
+	let keywordKeys = null;
 
-	return reverseKeywords[rgb];
-}
+	const fill = () => {
+		filled = true;
+		if (keywords === null) {
+			keywords = {};
+			keywordKeys = Object.keys(cssKeywords);
+			for (const key of keywordKeys) {
+				keywords[cssKeywords[key]] = key;
+			}
+		}
+	};
+
+	const all = () => {
+		if (filled === false) {
+			fill();
+		}
+
+		return keywordKeys;
+	};
+
+	const find = rgb => {
+		if (filled === false) {
+			fill();
+		}
+
+		return keywords[rgb];
+	};
+
+	return {all, find};
+})(cssKeywords);
 
 const convert = {
 	rgb: {channels: 3, labels: 'rgb'},
@@ -182,7 +205,7 @@ function comparativeDistance(x, y) {
 }
 
 convert.rgb.keyword = function (rgb) {
-	const reversed = findReverseKeyword(rgb);
+	const reversed = reverseKeywords.find(rgb);
 	if (reversed) {
 		return reversed;
 	}
@@ -190,7 +213,7 @@ convert.rgb.keyword = function (rgb) {
 	let currentClosestDistance = Infinity;
 	let currentClosestKeyword;
 
-	for (const keyword of Object.keys(cssKeywords)) {
+	for (const keyword of reverseKeywords.all()) {
 		const value = cssKeywords[keyword];
 
 		// Compute comparative distance

--- a/conversions.js
+++ b/conversions.js
@@ -22,7 +22,7 @@ const reverseKeywords = (cssKeywords => {
 		}
 	};
 
-	const all = () => {
+	const allKeys = () => {
 		if (filled === false) {
 			fill();
 		}
@@ -38,7 +38,11 @@ const reverseKeywords = (cssKeywords => {
 		return keywords[rgb];
 	};
 
-	return {all, find};
+	const each = callback => {
+		allKeys().forEach(key => callback(key, cssKeywords[key]));
+	};
+
+	return {allKeys, find, each};
 })(cssKeywords);
 
 const convert = {
@@ -213,18 +217,16 @@ convert.rgb.keyword = function (rgb) {
 	let currentClosestDistance = Infinity;
 	let currentClosestKeyword;
 
-	for (const keyword of reverseKeywords.all()) {
-		const value = cssKeywords[keyword];
-
+	reverseKeywords.each((key, value) => {
 		// Compute comparative distance
 		const distance = comparativeDistance(rgb, value);
 
 		// Check if its less, if so set as closest
 		if (distance < currentClosestDistance) {
 			currentClosestDistance = distance;
-			currentClosestKeyword = keyword;
+			currentClosestKeyword = key;
 		}
-	}
+	});
 
 	return currentClosestKeyword;
 };


### PR DESCRIPTION
We had a `for` in the root of `conversions.js` but it used just in `convert.rgb.keyword`, so I created a function to prevent run this `for`. It just runs when need it.