### PR TITLE
upgrade color-name dependency to ESM version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "xo": "^0.24.0"
   },
   "dependencies": {
-    "color-name": "~1.1.4"
+    "color-name": "~2.0.0"
   }
 }


### PR DESCRIPTION
The `color-name` dependency was recently updated to use ESM, and released their package `v2.0.0` with the only change being to use ESM default export. As a followup to #102, in the process of updating this package to ESM, we should also update our sole dependency to its ESM version.

I have specifically omitted changing the import style in this PR, and updating the `package.json` to `"type": "module"`. As those changes have already been made in #102, and would be duplicative here.

_So -- just a fair warning -- the first round of tests will fail because of incorrect import style._

But once that #102  is merged, we can immediately pull `master` into this branch. And at that time, it will pass tests.